### PR TITLE
News詳細の崩れ修正

### DIFF
--- a/source/assets/stylesheets/components/_entry.styl
+++ b/source/assets/stylesheets/components/_entry.styl
@@ -40,7 +40,7 @@
         padding 30px 30px 35px
 
     .entry__textareaInner
-      max-width 640px
+      max-width 700px
       margin 0 auto
 
   &--news
@@ -66,7 +66,7 @@
       color $textColor_inverse
       max-width 700px
       margin 0 auto
-      padding 55px 60px 60px
+      padding 55px 0 60px
 
       +media-query($mq_tablet)
         padding 40px
@@ -142,7 +142,7 @@
   img
     line-height 0
     margin 0 0 1.2em
-    max-width 100%
+    width 100%
     height auto
     vertical-align top
 

--- a/source/javascripts/pages/Single.vue
+++ b/source/javascripts/pages/Single.vue
@@ -120,6 +120,11 @@ export default {
 
         // 画像読み込み後にフェードイン
         $(this.$els.entry).imagesLoaded(() => {
+          // postTypeがnewsだったら、画像を大きいのに差し替える
+          if (this.post.type === 'text') {
+            this.replaceImage();
+          }
+
           // Twitterの埋め込みツイートがあったら関数実行
           if ($('body').find('.twitter-tweet')[0]) {
             twttr.widgets.load(document.body);
@@ -143,6 +148,21 @@ export default {
   filters: {
     moment: (timestamp) => {
       return store.actions.formatDate(timestamp);
+    }
+  },
+
+  methods: {
+    replaceImage: function(){
+      const images = $(this.$els.entry).find('img');
+
+      images.each((id, value)=>{
+        let src = $(value).attr('src');
+
+        if( /media\.tumblr\.com/.test(src) && !/(avatar|assets)/.test(src) && /\.(jpg|jpeg|png|bmp)$/.test(src) ) {
+          src = src.replace( /_\d{1,4}(\.)(jpg|jpeg|png|bmp)$/, '_1280$1$2' );
+          $(value).attr('src', src);
+        }
+      });
     }
   }
 };


### PR DESCRIPTION
画像の解像度が小さくて、テキストが回り込んでしまっていたので
- ゴリ押しでデカい画像に差し替える
  - ゴリ押し: https://gist.github.com/ryonakae/9054ce7372bab46cc0b1
- ついでにWork詳細の本文の幅もNews詳細に合わせる
